### PR TITLE
Add command-line todo manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+data/todos.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Todo Manager
+
+A simple command-line tool to manage project tasks with subtasks, daily and weekly views.
+
+## Features
+
+- Organise todos across multiple projects
+- Create subtasks for each todo
+- Assign deadlines (due dates) and assignees
+- List all todos or filter by daily and weekly deadlines
+- Mark tasks as completed
+
+## Usage
+
+```bash
+python -m todo_manager add "Write documentation" --project docs --due 2025-01-01
+python -m todo_manager list
+python -m todo_manager daily
+python -m todo_manager weekly
+```
+
+Todos are stored in `data/todos.json`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,29 @@
+from todo_manager.todo import Todo, TodoStore
+
+
+def test_add_and_list(tmp_path, monkeypatch):
+    path = tmp_path / "todos.json"
+    monkeypatch.setattr("todo_manager.todo.DATA_FILE", path)
+
+    store = TodoStore()
+    store.add(Todo(title="Task 1"))
+    store.add(Todo(title="Task 2"))
+
+    todos = store.list_all()
+    assert len(todos) == 2
+    assert todos[0].title == "Task 1"
+    assert todos[1].title == "Task 2"
+
+
+def test_add_subtask(tmp_path, monkeypatch):
+    path = tmp_path / "todos.json"
+    monkeypatch.setattr("todo_manager.todo.DATA_FILE", path)
+
+    store = TodoStore()
+    store.add(Todo(title="Parent"))
+    store.add_subtask(1, Todo(title="Child"))
+
+    parent = store.get(1)
+    assert parent is not None
+    assert len(parent.subtasks) == 1
+    assert parent.subtasks[0].title == "Child"

--- a/todo_manager/__main__.py
+++ b/todo_manager/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == '__main__':
+    main()

--- a/todo_manager/cli.py
+++ b/todo_manager/cli.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+from datetime import date, timedelta
+from typing import List
+
+from .todo import Todo, TodoStore
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Todo manager")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    add_p = sub.add_parser("add", help="Add a new todo")
+    add_p.add_argument("title", help="Title of the todo")
+    add_p.add_argument("--project")
+    add_p.add_argument("--description", default="")
+    add_p.add_argument("--due", help="Due date in YYYY-MM-DD format")
+    add_p.add_argument("--assignees", nargs="*", default=[])
+    add_p.add_argument("--parent", type=int, help="ID of parent todo for subtask")
+
+    sub.add_parser("list", help="List all todos")
+
+    sub.add_parser("daily", help="List todos due today")
+    sub.add_parser("weekly", help="List todos due this week")
+
+    complete_p = sub.add_parser("complete", help="Mark todo as completed")
+    complete_p.add_argument("id", type=int)
+
+    return parser
+
+
+def print_todos(todos: List[Todo]) -> None:
+    for todo in todos:
+        status = "[x]" if todo.completed else "[ ]"
+        line = f"{status} {todo.id}: {todo.title}"
+        if todo.project:
+            line += f" (project: {todo.project})"
+        if todo.due:
+            line += f" due {todo.due}"
+        if todo.assignees:
+            line += f" assignees: {', '.join(todo.assignees)}"
+        print(line)
+        for sub in todo.subtasks:
+            sub_status = "[x]" if sub.completed else "[ ]"
+            print(f"    {sub_status} {sub.id}: {sub.title}")
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    store = TodoStore()
+
+    if args.command == "add":
+        todo = Todo(
+            title=args.title,
+            project=args.project,
+            description=args.description,
+            due=args.due,
+            assignees=args.assignees,
+        )
+        if args.parent:
+            if not store.add_subtask(args.parent, todo):
+                parser.error(f"Parent todo with id {args.parent} not found")
+        else:
+            store.add(todo)
+        return
+
+    if args.command == "list":
+        print_todos(store.list_all())
+        return
+
+    if args.command == "complete":
+        if not store.mark_complete(args.id):
+            parser.error(f"Todo with id {args.id} not found")
+        return
+
+    today = date.today()
+    if args.command == "daily":
+        todos = store.filter_by_due_range(today, today)
+        print_todos(todos)
+        return
+
+    if args.command == "weekly":
+        end = today + timedelta(days=7)
+        todos = store.filter_by_due_range(today, end)
+        print_todos(todos)
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/todo_manager/todo.py
+++ b/todo_manager/todo.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from datetime import date
+from pathlib import Path
+from typing import List, Optional
+
+
+DATA_FILE = Path(__file__).resolve().parent.parent / 'data' / 'todos.json'
+
+
+def _load_data() -> List[dict]:
+    if DATA_FILE.exists():
+        with DATA_FILE.open('r', encoding='utf-8') as fh:
+            try:
+                return json.load(fh)
+            except json.JSONDecodeError:
+                return []
+    return []
+
+
+def _save_data(data: List[dict]) -> None:
+    DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with DATA_FILE.open('w', encoding='utf-8') as fh:
+        json.dump(data, fh, indent=2)
+
+
+@dataclass
+class Todo:
+    title: str
+    project: Optional[str] = None
+    description: str = ""
+    due: Optional[str] = None  # ISO formatted date string
+    assignees: List[str] = field(default_factory=list)
+    subtasks: List["Todo"] = field(default_factory=list)
+    completed: bool = False
+    id: int = field(default=0)
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data['subtasks'] = [t.to_dict() for t in self.subtasks]
+        return data
+
+    @staticmethod
+    def from_dict(data: dict) -> "Todo":
+        subtasks = [Todo.from_dict(t) for t in data.get('subtasks', [])]
+        data = {k: v for k, v in data.items() if k != 'subtasks'}
+        todo = Todo(**data)
+        todo.subtasks = subtasks
+        return todo
+
+
+class TodoStore:
+    def __init__(self) -> None:
+        self.todos: List[Todo] = [Todo.from_dict(d) for d in _load_data()]
+        self._next_id = max([t.id for t in self.todos], default=0) + 1
+
+    def add(self, todo: Todo) -> None:
+        todo.id = self._next_id
+        self._next_id += 1
+        self.todos.append(todo)
+        self.save()
+
+    def save(self) -> None:
+        _save_data([t.to_dict() for t in self.todos])
+
+    def list_all(self) -> List[Todo]:
+        return list(self.todos)
+
+    def get(self, todo_id: int) -> Optional[Todo]:
+        for todo in self.todos:
+            if todo.id == todo_id:
+                return todo
+        return None
+
+    def mark_complete(self, todo_id: int) -> bool:
+        todo = self.get(todo_id)
+        if todo:
+            todo.completed = True
+            self.save()
+            return True
+        return False
+
+    def add_subtask(self, parent_id: int, subtask: Todo) -> bool:
+        parent = self.get(parent_id)
+        if parent:
+            subtask.id = self._next_id
+            self._next_id += 1
+            parent.subtasks.append(subtask)
+            self.save()
+            return True
+        return False
+
+    def filter_by_due_range(self, start: date, end: date) -> List[Todo]:
+        result = []
+        for todo in self.todos:
+            if todo.due:
+                try:
+                    due_date = date.fromisoformat(todo.due)
+                except ValueError:
+                    continue
+                if start <= due_date <= end:
+                    result.append(todo)
+        return result


### PR DESCRIPTION
## Summary
- add README with overview and usage instructions
- create todo management package with CLI entry point
- support storing tasks and subtasks in JSON file
- implement `TodoStore` with CRUD methods
- provide CLI commands for adding, listing, completing tasks and showing daily/weekly views
- add basic tests for todo store

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684416391c908327a1b33d97ec6a119b